### PR TITLE
Potential fix for code scanning alert no. 52: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_pr-fb.yaml
+++ b/.github/workflows/_pr-fb.yaml
@@ -25,6 +25,9 @@ on:
 jobs:
   pr-feedback:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     ## コードをチェックアウト
     - name: checkout source


### PR DESCRIPTION
Potential fix for [https://github.com/ubata-mamezou/consider-cicd/security/code-scanning/52](https://github.com/ubata-mamezou/consider-cicd/security/code-scanning/52)

To fix the problem, we need to add a `permissions` block to restrict the permissions granted to the GITHUB_TOKEN used by the workflow/job. For best security, specify the minimum required privileges. Since this job downloads artifacts and posts PR comments, it needs:
- Permission to read repository contents (`contents: read`) for actions like checkout.
- Permission to write to pull requests (`pull-requests: write`) in order to post PR comments.

Add the following under the job definition (`pr-feedback:`) or at the workflow root for all jobs. As context suggests only one job, adding under `pr-feedback:` is clearest. Place the `permissions` block directly below `runs-on: ubuntu-latest` (i.e., before the `steps:` block) in `.github/workflows/_pr-fb.yaml`.

No additional dependencies, imports, or code changes are required—just an edit to the workflow YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
